### PR TITLE
"split" function is deprecated.  Replaced with calls to "preg_split".

### DIFF
--- a/class.gaparse.php
+++ b/class.gaparse.php
@@ -43,7 +43,7 @@ class GA_Parse
   function ParseCookies(){
 
   // Parse __utmz cookie
-  list($domain_hash,$timestamp, $session_number, $campaign_numer, $campaign_data) = split('[\.]', $_COOKIE["__utmz"],5);
+  list($domain_hash,$timestamp, $session_number, $campaign_numer, $campaign_data) = preg_split('[\.]', $_COOKIE["__utmz"],5);
 
   // Parse the campaign data
   $campaign_data = parse_str(strtr($campaign_data, "|", "&"));
@@ -67,7 +67,7 @@ class GA_Parse
   }
 
   // Parse the __utma Cookie
-  list($domain_hash,$random_id,$time_initial_visit,$time_beginning_previous_visit,$time_beginning_current_visit,$session_counter) = split('[\.]', $_COOKIE["__utma"]);
+  list($domain_hash,$random_id,$time_initial_visit,$time_beginning_previous_visit,$time_beginning_current_visit,$session_counter) = preg_split('[\.]', $_COOKIE["__utma"]);
 
   $this->first_visit = date("d M Y - H:i",$time_initial_visit);
   $this->previous_visit = date("d M Y - H:i",$time_beginning_previous_visit);
@@ -76,7 +76,7 @@ class GA_Parse
 
   // Parse the __utmb Cookie
 
-  list($domain_hash,$pages_viewed,$garbage,$time_beginning_current_session) = split('[\.]', $_COOKIE["__utmb"]);
+  list($domain_hash,$pages_viewed,$garbage,$time_beginning_current_session) = preg_split('[\.]', $_COOKIE["__utmb"]);
   $this->pages_viewed = $pages_viewed;
 
 

--- a/class.gaparse.php
+++ b/class.gaparse.php
@@ -69,9 +69,15 @@ class GA_Parse
   // Parse the __utma Cookie
   list($domain_hash,$random_id,$time_initial_visit,$time_beginning_previous_visit,$time_beginning_current_visit,$session_counter) = preg_split('[\.]', $_COOKIE["__utma"]);
 
-  $this->first_visit = date("d M Y - H:i",$time_initial_visit);
-  $this->previous_visit = date("d M Y - H:i",$time_beginning_previous_visit);
-  $this->current_visit_started = date("d M Y - H:i",$time_beginning_current_visit);
+  $this->first_visit = new \DateTime();
+  $this->first_visit->setTimestamp($time_initial_visit);
+
+  $this->previous_visit = new \DateTime();
+  $this->previous_visit->setTimestamp($time_beginning_previous_visit);
+
+  $this->current_visit_started = new \DateTime();
+  $this->current_visit_started->setTimestamp($time_beginning_current_visit);
+
   $this->times_visited = $session_counter;
 
   // Parse the __utmb Cookie


### PR DESCRIPTION
Greetings,

I was trying out your parser and encountered a warning (which is elevated to an error in Silex) saying that the "split" function was deprecated.  Looking on php.net, I found this to indeed be the case and they recommend using preg_split instead.  I swapped out calls to split with preg_split and the parser still works.

I didn't extensively test this, but a few trial runs seemed to work out.  Feel free to do whatever you like with this.
