### PR TITLE
Replaced split with preg_split.

### DIFF
--- a/class.gaparse.php
+++ b/class.gaparse.php
@@ -5,12 +5,14 @@
 // Version 1.0 - Date: 17 September 2009
 // Version 1.1 - Date: 25 January 2012
 // Version 1.2 - Date: 21 April 2012
+// Version 1.3 - Date: 12 June 2013
 //
 // Define a PHP class that can be used to parse 
 // Google Analytics cookies currently with support
 // for __utmz (campaign data) and __utma (visitor data)
 //
 // Author: Joao Correia - http://joaocorreia.pt
+// Contrib by: Dan Garfield - http://todaywasawesome.com
 //
 // License: LGPL
 //
@@ -69,22 +71,17 @@ class GA_Parse
   // Parse the __utma Cookie
   list($domain_hash,$random_id,$time_initial_visit,$time_beginning_previous_visit,$time_beginning_current_visit,$session_counter) = preg_split('[\.]', $_COOKIE["__utma"]);
 
-  $this->first_visit = new \DateTime();
-  $this->first_visit->setTimestamp($time_initial_visit);
-
-  $this->previous_visit = new \DateTime();
-  $this->previous_visit->setTimestamp($time_beginning_previous_visit);
-
-  $this->current_visit_started = new \DateTime();
-  $this->current_visit_started->setTimestamp($time_beginning_current_visit);
-
+  $this->first_visit = date("d M Y - H:i",$time_initial_visit);
+  $this->previous_visit = date("d M Y - H:i",$time_beginning_previous_visit);
+  $this->current_visit_started = date("d M Y - H:i",$time_beginning_current_visit);
   $this->times_visited = $session_counter;
 
   // Parse the __utmb Cookie
-
-  list($domain_hash,$pages_viewed,$garbage,$time_beginning_current_session) = preg_split('[\.]', $_COOKIE["__utmb"]);
-  $this->pages_viewed = $pages_viewed;
-
+  // The __utmb Cookie is only set by the 2nd visit.
+  if(isset($_COOKIE["__utmb"])){
+    list($domain_hash,$pages_viewed,$garbage,$time_beginning_current_session) = preg_split('[\.]', $_COOKIE["__utmb"]);
+    $this->pages_viewed = $pages_viewed;
+  }
 
  // End ParseCookies
  }  


### PR DESCRIPTION
Split is deprecated so I rewrote it using preg_split. It's been working well for me after 60,000+ hits in a production environment.

In the file, I added my name to the credits, feel free to remove that. I didn't make THAT big of a contribution. I have it in my local copy so I know what changes I've made.

Thanks for the awesome project.
