### PR TITLE
Fixing fatal error in PHP 5.3.28

### DIFF
--- a/class.gaparse.php
+++ b/class.gaparse.php
@@ -32,7 +32,7 @@ class GA_Parse
   var $pages_viewed;			// Pages viewed in current session
   
   
-  function __construct($_COOKIE) {
+  function __construct($cookie = false) {
 	   // If we have the cookies we can go ahead and parse them.
 	   if (isset($_COOKIE["__utma"]) and isset($_COOKIE["__utmz"])) {
 	       $this->ParseCookies();      


### PR DESCRIPTION
Fatal error: Cannot re-assign auto-global variable _COOKIE
